### PR TITLE
improve editor selection

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,6 +51,9 @@ var editCmd = &cobra.Command{
 
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
+			editor = os.Getenv("VISUAL")
+		}
+		if editor == "" {
 			editor = "vi"
 		}
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,7 @@ var editCmd = &cobra.Command{
 
 		editor := os.Getenv("EDITOR")
 		if editor == "" {
-			editor = "vim"
+			editor = "vi"
 		}
 
 		editCmd := exec.Command(editor, tmpFile.Name())


### PR DESCRIPTION
when the EDITOR envvar is empty, it now falls back to VISUAL as expected from unix programms.
It now also uses vi instead of vim as the last fallback as expected from unix programms.